### PR TITLE
Expose restart flag

### DIFF
--- a/cjs/Assist.d.ts
+++ b/cjs/Assist.d.ts
@@ -17,7 +17,7 @@ export default class Assist {
     constructor(app: App, options?: Partial<Options>);
     private emit;
     private get agentsConnected();
-    get isRestarting(): boolean;
+    get forcingTrackerRestart(): boolean;
     private getHost;
     private getBasePrefixUrl;
     private onStart;

--- a/cjs/Assist.d.ts
+++ b/cjs/Assist.d.ts
@@ -17,6 +17,7 @@ export default class Assist {
     constructor(app: App, options?: Partial<Options>);
     private emit;
     private get agentsConnected();
+    get isRestarting(): boolean;
     private getHost;
     private getBasePrefixUrl;
     private onStart;

--- a/cjs/Assist.js
+++ b/cjs/Assist.js
@@ -52,6 +52,9 @@ class Assist {
     get agentsConnected() {
         return Object.keys(this.agents).length > 0;
     }
+    get isRestarting() {
+        return this.assistDemandedRestart;
+    }
     getHost() {
         if (this.options.serverURL) {
             return new URL(this.options.serverURL).host;

--- a/cjs/Assist.js
+++ b/cjs/Assist.js
@@ -52,7 +52,7 @@ class Assist {
     get agentsConnected() {
         return Object.keys(this.agents).length > 0;
     }
-    get isRestarting() {
+    get forcingTrackerRestart() {
         return this.assistDemandedRestart;
     }
     getHost() {

--- a/lib/Assist.d.ts
+++ b/lib/Assist.d.ts
@@ -17,7 +17,7 @@ export default class Assist {
     constructor(app: App, options?: Partial<Options>);
     private emit;
     private get agentsConnected();
-    get isRestarting(): boolean;
+    get forcingTrackerRestart(): boolean;
     private getHost;
     private getBasePrefixUrl;
     private onStart;

--- a/lib/Assist.d.ts
+++ b/lib/Assist.d.ts
@@ -17,6 +17,7 @@ export default class Assist {
     constructor(app: App, options?: Partial<Options>);
     private emit;
     private get agentsConnected();
+    get isRestarting(): boolean;
     private getHost;
     private getBasePrefixUrl;
     private onStart;

--- a/lib/Assist.js
+++ b/lib/Assist.js
@@ -50,6 +50,9 @@ export default class Assist {
     get agentsConnected() {
         return Object.keys(this.agents).length > 0;
     }
+    get isRestarting() {
+        return this.assistDemandedRestart;
+    }
     getHost() {
         if (this.options.serverURL) {
             return new URL(this.options.serverURL).host;

--- a/lib/Assist.js
+++ b/lib/Assist.js
@@ -50,7 +50,7 @@ export default class Assist {
     get agentsConnected() {
         return Object.keys(this.agents).length > 0;
     }
-    get isRestarting() {
+    get forcingTrackerRestart() {
         return this.assistDemandedRestart;
     }
     getHost() {

--- a/src/Assist.ts
+++ b/src/Assist.ts
@@ -83,7 +83,7 @@ export default class Assist {
     return Object.keys(this.agents).length > 0
   }
 
-  get isRestarting(): boolean {
+  get forcingTrackerRestart(): boolean {
     return this.assistDemandedRestart
   }
 

--- a/src/Assist.ts
+++ b/src/Assist.ts
@@ -83,6 +83,10 @@ export default class Assist {
     return Object.keys(this.agents).length > 0
   }
 
+  get isRestarting(): boolean {
+    return this.assistDemandedRestart
+  }
+
   private getHost():string{
     if (this.options.serverURL){
       return new URL(this.options.serverURL).host


### PR DESCRIPTION
## Context
Expose the flag that says "assist forced tracker to restart" so we can use this to tell why the tracker restarted. We need this on the frontend because we dont want to generate a new OpenReplay session if it's a tracker restart. 